### PR TITLE
Fix launch crash from Bundle.module and the endless Keychain prompts

### DIFF
--- a/Sources/Nootch/Adapters.swift
+++ b/Sources/Nootch/Adapters.swift
@@ -96,6 +96,83 @@ struct CodexAdapter: ProviderAdapter {
 import Foundation
 import Security
 
+enum TokenLookup: Equatable {
+    case found(String)
+    // Nothing stored anywhere. Re-reading is cheap and raises no prompt, so
+    // this expires quickly and a fresh `claude login` shows up promptly.
+    case absent
+    // The Keychain refused: the prompt was cancelled, or authentication
+    // failed. Re-reading means another password dialog, so back off hard.
+    case denied
+}
+
+// A Keychain read of "Claude Code-credentials" can raise a system password
+// prompt, and the refresh loop runs every 30s. Caching the result keeps a
+// signed build to one prompt per TTL, and keeps an unsigned or denied one from
+// producing a dialog every half minute.
+final class TokenCache: @unchecked Sendable {
+    static let foundTTL: TimeInterval = 300
+    static let absentTTL: TimeInterval = 30
+    static let deniedTTL: TimeInterval = 600
+    // Floor between a rejected token and the next read, so a token the API
+    // keeps refusing cannot turn into a prompt every cycle.
+    static let reloadFloor: TimeInterval = 120
+
+    private let lock = NSLock()
+    private let now: @Sendable () -> Date
+    private var token: String?
+    private var expiresAt: Date?
+    private var earliestReload: Date?
+
+    init(now: @escaping @Sendable () -> Date = { Date() }) {
+        self.now = now
+    }
+
+    /// - Parameter loader: run while the lock is held, so it must not call back
+    ///   into the cache. It is only ever the Keychain/file read in ClaudeAdapter.
+    func value(loader: () -> TokenLookup) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        let now = now()
+        if let expiresAt, now < expiresAt { return token }
+        // Expired, but still inside the post-rejection floor: keep serving the
+        // stale token so the "login expired" error stays put instead of the row
+        // flipping to undetected, and do not touch the Keychain.
+        if let earliestReload, now < earliestReload { return token }
+
+        let ttl: TimeInterval
+        switch loader() {
+        case let .found(value):
+            token = value
+            ttl = Self.foundTTL
+        case .absent:
+            token = nil
+            ttl = Self.absentTTL
+        case .denied:
+            token = nil
+            ttl = Self.deniedTTL
+        }
+        expiresAt = now.addingTimeInterval(ttl)
+        earliestReload = nil
+        return token
+    }
+
+    /// Drops the cached token after the API rejected it, holding a short floor
+    /// before the next read.
+    func invalidate() {
+        lock.lock()
+        defer { lock.unlock() }
+        expiresAt = nil
+        // Only arm the floor when one is not already pending. Rearming on every
+        // rejection would push it out by another two minutes each refresh, and
+        // since the stale token keeps being served the floor would never lapse
+        // — the Keychain would never be read again and a re-login would not be
+        // noticed until restart.
+        guard earliestReload == nil else { return }
+        earliestReload = now().addingTimeInterval(Self.reloadFloor)
+    }
+}
+
 struct ClaudeAdapter: ProviderAdapter {
     let provider: ProviderID = .claude
 
@@ -186,71 +263,7 @@ struct ClaudeAdapter: ProviderAdapter {
         }
     }
 
-    private enum TokenLookup {
-        case found(String)
-        // Nothing stored anywhere. Re-reading is cheap and raises no prompt, so
-        // this expires quickly and a fresh `claude login` shows up promptly.
-        case absent
-        // The Keychain refused: the prompt was cancelled, or authentication
-        // failed. Re-reading means another password dialog, so back off hard.
-        case denied
-    }
-
-    // A Keychain read of "Claude Code-credentials" can raise a system password
-    // prompt, and the refresh loop runs every 30s. Caching the result keeps a
-    // signed build to one prompt per TTL, and keeps an unsigned or denied one
-    // from producing a dialog every half minute.
-    private final class TokenCache: @unchecked Sendable {
-        private static let foundTTL: TimeInterval = 300
-        private static let absentTTL: TimeInterval = 30
-        private static let deniedTTL: TimeInterval = 600
-        // Floor between a rejected token and the next read, so a token the API
-        // keeps refusing cannot turn into a prompt every cycle.
-        private static let reloadFloor: TimeInterval = 120
-
-        private let lock = NSLock()
-        private var token: String?
-        private var expiresAt: Date?
-        private var earliestReload: Date?
-
-        // `loader` runs while the lock is held, so it must not call back into
-        // the cache. It is only ever the Keychain/file read below.
-        func value(loader: () -> TokenLookup) -> String? {
-            lock.lock()
-            defer { lock.unlock() }
-            let now = Date()
-            if let expiresAt, now < expiresAt { return token }
-            // Expired, but still inside the post-rejection floor: keep serving
-            // the stale token so the "login expired" error stays put instead of
-            // the row flipping to undetected, and do not touch the Keychain.
-            if let earliestReload, now < earliestReload { return token }
-
-            let ttl: TimeInterval
-            switch loader() {
-            case let .found(value):
-                token = value
-                ttl = Self.foundTTL
-            case .absent:
-                token = nil
-                ttl = Self.absentTTL
-            case .denied:
-                token = nil
-                ttl = Self.deniedTTL
-            }
-            expiresAt = now.addingTimeInterval(ttl)
-            earliestReload = nil
-            return token
-        }
-
-        func invalidate() {
-            lock.lock()
-            defer { lock.unlock() }
-            expiresAt = nil
-            earliestReload = Date().addingTimeInterval(Self.reloadFloor)
-        }
-    }
-
-    private static let tokenCache = TokenCache()
+    static let tokenCache = TokenCache()
 
     private static func environmentToken() -> String? {
         guard let token = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]?

--- a/Sources/Nootch/Adapters.swift
+++ b/Sources/Nootch/Adapters.swift
@@ -152,7 +152,11 @@ final class TokenCache: @unchecked Sendable {
             token = nil
             ttl = Self.deniedTTL
         }
-        expiresAt = now.addingTimeInterval(ttl)
+        // Measured after the load, not before: a Keychain read that sits behind
+        // a password dialog can outlast the TTL, and dating the entry from
+        // before it would leave it already expired on arrival — the next cycle
+        // would read again and prompt again.
+        expiresAt = self.now().addingTimeInterval(ttl)
         earliestReload = nil
         return token
     }
@@ -263,7 +267,7 @@ struct ClaudeAdapter: ProviderAdapter {
         }
     }
 
-    static let tokenCache = TokenCache()
+    private static let tokenCache = TokenCache()
 
     private static func environmentToken() -> String? {
         guard let token = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]?

--- a/Sources/Nootch/Adapters.swift
+++ b/Sources/Nootch/Adapters.swift
@@ -117,7 +117,17 @@ struct ClaudeAdapter: ProviderAdapter {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else { throw ClaudeError.invalidResponse }
-            guard http.statusCode == 200 else { throw ClaudeError.http(http.statusCode) }
+            guard http.statusCode == 200 else {
+                // The cached token is no longer good; drop it so the next cycle
+                // re-reads instead of waiting out the TTL on a stale value.
+                // Only worth doing when the cache is what supplied the token;
+                // an env-var token is never cached, so clearing would be a
+                // no-op that just hides the real problem.
+                if http.statusCode == 401 || http.statusCode == 403, Self.environmentToken() == nil {
+                    Self.tokenCache.invalidate()
+                }
+                throw ClaudeError.http(http.statusCode)
+            }
             let usage = try JSONDecoder().decode(Response.self, from: data)
             return ProviderStatus(
                 provider: .claude,
@@ -176,10 +186,85 @@ struct ClaudeAdapter: ProviderAdapter {
         }
     }
 
-    private static func accessToken() -> String? {
-        if let token = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+    private enum TokenLookup {
+        case found(String)
+        // Nothing stored anywhere. Re-reading is cheap and raises no prompt, so
+        // this expires quickly and a fresh `claude login` shows up promptly.
+        case absent
+        // The Keychain refused: the prompt was cancelled, or authentication
+        // failed. Re-reading means another password dialog, so back off hard.
+        case denied
+    }
+
+    // A Keychain read of "Claude Code-credentials" can raise a system password
+    // prompt, and the refresh loop runs every 30s. Caching the result keeps a
+    // signed build to one prompt per TTL, and keeps an unsigned or denied one
+    // from producing a dialog every half minute.
+    private final class TokenCache: @unchecked Sendable {
+        private static let foundTTL: TimeInterval = 300
+        private static let absentTTL: TimeInterval = 30
+        private static let deniedTTL: TimeInterval = 600
+        // Floor between a rejected token and the next read, so a token the API
+        // keeps refusing cannot turn into a prompt every cycle.
+        private static let reloadFloor: TimeInterval = 120
+
+        private let lock = NSLock()
+        private var token: String?
+        private var expiresAt: Date?
+        private var earliestReload: Date?
+
+        // `loader` runs while the lock is held, so it must not call back into
+        // the cache. It is only ever the Keychain/file read below.
+        func value(loader: () -> TokenLookup) -> String? {
+            lock.lock()
+            defer { lock.unlock() }
+            let now = Date()
+            if let expiresAt, now < expiresAt { return token }
+            // Expired, but still inside the post-rejection floor: keep serving
+            // the stale token so the "login expired" error stays put instead of
+            // the row flipping to undetected, and do not touch the Keychain.
+            if let earliestReload, now < earliestReload { return token }
+
+            let ttl: TimeInterval
+            switch loader() {
+            case let .found(value):
+                token = value
+                ttl = Self.foundTTL
+            case .absent:
+                token = nil
+                ttl = Self.absentTTL
+            case .denied:
+                token = nil
+                ttl = Self.deniedTTL
+            }
+            expiresAt = now.addingTimeInterval(ttl)
+            earliestReload = nil
             return token
         }
+
+        func invalidate() {
+            lock.lock()
+            defer { lock.unlock() }
+            expiresAt = nil
+            earliestReload = Date().addingTimeInterval(Self.reloadFloor)
+        }
+    }
+
+    private static let tokenCache = TokenCache()
+
+    private static func environmentToken() -> String? {
+        guard let token = ProcessInfo.processInfo.environment["CLAUDE_CODE_OAUTH_TOKEN"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty
+        else { return nil }
+        return token
+    }
+
+    private static func accessToken() -> String? {
+        if let token = environmentToken() { return token }
+        return tokenCache.value(loader: lookupToken)
+    }
+
+    private static func lookupToken() -> TokenLookup {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: "Claude Code-credentials",
@@ -187,9 +272,30 @@ struct ClaudeAdapter: ProviderAdapter {
             kSecMatchLimit: kSecMatchLimitOne,
         ]
         var result: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
-              let data = result as? Data,
-              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess,
+           let data = result as? Data,
+           let token = oauthAccessToken(from: data) {
+            return .found(token)
+        }
+        if let token = credentialsFileToken() { return .found(token) }
+        // errSecItemNotFound means there is simply nothing stored; anything else
+        // is the Keychain declining to hand it over.
+        return status == errSecItemNotFound ? .absent : .denied
+    }
+
+    // Claude Code also writes ~/.claude/.credentials.json on some setups. It is
+    // only a fallback: the Keychain stays authoritative so a refreshed token is
+    // never shadowed by a stale file.
+    private static func credentialsFileToken() -> String? {
+        let url = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent(".claude/.credentials.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return oauthAccessToken(from: data)
+    }
+
+    private static func oauthAccessToken(from data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let oauth = object["claudeAiOauth"] as? [String: Any],
               let token = oauth["accessToken"] as? String,
               !token.isEmpty

--- a/Sources/Nootch/NootchApp.swift
+++ b/Sources/Nootch/NootchApp.swift
@@ -37,7 +37,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppSettings.configure()
         applyDockVisibility()
-        if let iconURL = Bundle.module.url(forResource: "NootchIcon", withExtension: "png"),
+        if let iconURL = ResourceBundle.url(forResource: "NootchIcon", withExtension: "png"),
            let icon = NSImage(contentsOf: iconURL) {
             icon.isTemplate = false
             NSApp.applicationIconImage = icon

--- a/Sources/Nootch/ProviderLogo.swift
+++ b/Sources/Nootch/ProviderLogo.swift
@@ -14,7 +14,7 @@ struct ProviderLogo: View {
         let key = NSString(string: provider.rawValue)
         if let cached = imageCache.object(forKey: key) { return cached }
         guard let resource = provider.logoResource,
-              let url = Bundle.module.url(forResource: resource, withExtension: nil),
+              let url = ResourceBundle.url(forResource: resource, withExtension: nil),
               let image = NSImage(contentsOf: url)
         else { return nil }
         imageCache.setObject(image, forKey: key)

--- a/Sources/Nootch/ResourceBundle.swift
+++ b/Sources/Nootch/ResourceBundle.swift
@@ -4,7 +4,7 @@ import os
 // SwiftPM's generated `Bundle.module` resolves the resource bundle relative to
 // the executable. For an `.app` that is the bundle root, not
 // `Contents/Resources` where a packaged app keeps its resources, so the lookup
-// misses and the generated accessor calls `assertionFailure` — the app dies
+// misses and the generated accessor calls `fatalError` — the app dies
 // during launch instead of degrading. Moving the bundle to the app root to
 // satisfy `Bundle.module` would leave unsealed contents there and invalidate
 // the code signature, so search the plausible locations here instead and let
@@ -17,26 +17,36 @@ enum ResourceBundle {
     // bundle is xctest, not the code under test.
     private final class ModuleAnchor {}
 
-    static let current: Bundle = {
-        var searched: [URL] = []
+    /// Directories that may hold the resource bundle, most specific first.
+    static func searchPaths(main: Bundle, anchor: Bundle) -> [URL] {
+        var paths: [URL] = []
         // Packaged .app: nootch.app/Contents/Resources/nootch_Nootch.bundle
-        if let resourceURL = Bundle.main.resourceURL { searched.append(resourceURL) }
+        if let resourceURL = main.resourceURL { paths.append(resourceURL) }
         // Bare SwiftPM build: alongside the executable, where Bundle.module looks.
-        if let executableDirectory = Bundle.main.executableURL?.resolvingSymlinksInPath().deletingLastPathComponent() {
-            searched.append(executableDirectory)
+        if let executableDirectory = main.executableURL?.resolvingSymlinksInPath().deletingLastPathComponent() {
+            paths.append(executableDirectory)
         }
-        searched.append(Bundle.main.bundleURL)
+        paths.append(main.bundleURL)
         // Any host process that is not the app itself, notably `swift test`,
-        // where the bundle is a sibling of the .xctest bundle rather than
-        // inside it.
-        let anchor = Bundle(for: ModuleAnchor.self)
-        if let anchorResources = anchor.resourceURL { searched.append(anchorResources) }
-        searched.append(anchor.bundleURL.deletingLastPathComponent())
+        // where the bundle is a sibling of the .xctest bundle rather than inside it.
+        if let anchorResources = anchor.resourceURL { paths.append(anchorResources) }
+        paths.append(anchor.bundleURL.deletingLastPathComponent())
+        return paths
+    }
 
-        for directory in searched {
+    /// Returns nil rather than trapping when the bundle is in none of
+    /// `directories`. This is the whole point of not using `Bundle.module`.
+    static func locate(in directories: [URL]) -> Bundle? {
+        for directory in directories {
             let candidate = directory.appendingPathComponent(bundleName)
             if let bundle = Bundle(url: candidate) { return bundle }
         }
+        return nil
+    }
+
+    static let current: Bundle = {
+        let searched = searchPaths(main: .main, anchor: Bundle(for: ModuleAnchor.self))
+        if let bundle = locate(in: searched) { return bundle }
         // Resources copied loose into the main bundle. Reaching here usually
         // means a broken install rather than a real layout: logos fall back to
         // SF Symbols and the dock icon disappears, which under LSUIElement is

--- a/Sources/Nootch/ResourceBundle.swift
+++ b/Sources/Nootch/ResourceBundle.swift
@@ -1,0 +1,52 @@
+import Foundation
+import os
+
+// SwiftPM's generated `Bundle.module` resolves the resource bundle relative to
+// the executable. For an `.app` that is the bundle root, not
+// `Contents/Resources` where a packaged app keeps its resources, so the lookup
+// misses and the generated accessor calls `assertionFailure` — the app dies
+// during launch instead of degrading. Moving the bundle to the app root to
+// satisfy `Bundle.module` would leave unsealed contents there and invalidate
+// the code signature, so search the plausible locations here instead and let
+// callers fall back when nothing is found.
+enum ResourceBundle {
+    private static let bundleName = "nootch_Nootch.bundle"
+
+    // Anchors `Bundle(for:)` to whatever binary this module ended up in, which
+    // is the one case Bundle.main cannot describe: under `swift test` the main
+    // bundle is xctest, not the code under test.
+    private final class ModuleAnchor {}
+
+    static let current: Bundle = {
+        var searched: [URL] = []
+        // Packaged .app: nootch.app/Contents/Resources/nootch_Nootch.bundle
+        if let resourceURL = Bundle.main.resourceURL { searched.append(resourceURL) }
+        // Bare SwiftPM build: alongside the executable, where Bundle.module looks.
+        if let executableDirectory = Bundle.main.executableURL?.resolvingSymlinksInPath().deletingLastPathComponent() {
+            searched.append(executableDirectory)
+        }
+        searched.append(Bundle.main.bundleURL)
+        // Any host process that is not the app itself, notably `swift test`,
+        // where the bundle is a sibling of the .xctest bundle rather than
+        // inside it.
+        let anchor = Bundle(for: ModuleAnchor.self)
+        if let anchorResources = anchor.resourceURL { searched.append(anchorResources) }
+        searched.append(anchor.bundleURL.deletingLastPathComponent())
+
+        for directory in searched {
+            let candidate = directory.appendingPathComponent(bundleName)
+            if let bundle = Bundle(url: candidate) { return bundle }
+        }
+        // Resources copied loose into the main bundle. Reaching here usually
+        // means a broken install rather than a real layout: logos fall back to
+        // SF Symbols and the dock icon disappears, which under LSUIElement is
+        // otherwise invisible. Leave a trace so it can be diagnosed.
+        Logger(subsystem: "com.deepanshumishraa.nootch", category: "resources")
+            .error("\(bundleName, privacy: .public) not found in \(searched.map(\.path), privacy: .public); falling back to the main bundle")
+        return Bundle.main
+    }()
+
+    static func url(forResource resource: String, withExtension extension: String?) -> URL? {
+        current.url(forResource: resource, withExtension: `extension`)
+    }
+}

--- a/Tests/NootchTests/ResourceBundleTests.swift
+++ b/Tests/NootchTests/ResourceBundleTests.swift
@@ -4,23 +4,62 @@ import Testing
 
 // Regression cover for the 1.0.4 launch crash: `Bundle.module` resolved the
 // resource bundle relative to the executable, missed it in a packaged .app, and
-// trapped instead of returning nil.
+// called fatalError instead of reporting the miss.
+
+// The crash itself. A packaged .app put the bundle somewhere Bundle.module did
+// not look, and the miss was fatal. `locate` has to report the miss instead, so
+// the app can degrade to SF Symbols.
+@Test func locateReturnsNilWhenBundleIsAbsentInsteadOfTrapping() throws {
+    let empty = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("nootch-resource-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: empty) }
+
+    #expect(ResourceBundle.locate(in: [empty]) == nil)
+    #expect(ResourceBundle.locate(in: []) == nil)
+}
+
+@Test func locateFindsBundleAndSkipsDirectoriesWithoutIt() throws {
+    let missing = URL(fileURLWithPath: NSTemporaryDirectory())
+        .appendingPathComponent("nootch-resource-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: missing, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: missing) }
+
+    let real = try #require(ResourceBundle.locate(in: ResourceBundle.searchPaths(
+        main: .main, anchor: Bundle(for: ProviderLogoAnchor.self))))
+    // A directory that does not hold the bundle must be skipped, not accepted.
+    let found = try #require(ResourceBundle.locate(in: [missing, real.bundleURL.deletingLastPathComponent()]))
+    #expect(found.bundleURL == real.bundleURL)
+}
+
+// The packaged .app keeps resources in Contents/Resources, so that has to be
+// tried before the executable directory Bundle.module used.
+@Test func searchPathsPrefersTheAppResourceDirectory() {
+    let paths = ResourceBundle.searchPaths(main: .main, anchor: Bundle(for: ProviderLogoAnchor.self))
+    let mainResources = try? #require(Bundle.main.resourceURL)
+    #expect(paths.first == mainResources)
+    #expect(!paths.isEmpty)
+}
+
 @Test func resourceBundleResolvesPackagedResources() {
     #expect(ResourceBundle.url(forResource: "claude", withExtension: "svg") != nil)
     #expect(ResourceBundle.url(forResource: "NootchIcon", withExtension: "png") != nil)
 }
 
-@Test func resourceBundleReturnsNilForMissingResourceInsteadOfTrapping() {
+@Test func resourceBundleReturnsNilForMissingResource() {
     #expect(ResourceBundle.url(forResource: "definitely-not-a-resource", withExtension: "svg") == nil)
 }
 
 // Every provider that advertises a logo must actually ship one, otherwise the
-// rail silently falls back to an SF Symbol.
+// rail silently falls back to an SF Symbol. ProviderID.allCases is a curated
+// display list that omits .openCodeGo, so cover that case explicitly.
 @Test func everyProviderLogoResourceIsPresent() {
-    for provider in ProviderID.allCases {
+    for provider in ProviderID.allCases + [.openCodeGo] {
         guard let resource = provider.logoResource else { continue }
         #expect(
             ResourceBundle.url(forResource: resource, withExtension: nil) != nil,
             "missing logo resource \(resource) for \(provider.rawValue)")
     }
 }
+
+private final class ProviderLogoAnchor {}

--- a/Tests/NootchTests/ResourceBundleTests.swift
+++ b/Tests/NootchTests/ResourceBundleTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import Nootch
+
+// Regression cover for the 1.0.4 launch crash: `Bundle.module` resolved the
+// resource bundle relative to the executable, missed it in a packaged .app, and
+// trapped instead of returning nil.
+@Test func resourceBundleResolvesPackagedResources() {
+    #expect(ResourceBundle.url(forResource: "claude", withExtension: "svg") != nil)
+    #expect(ResourceBundle.url(forResource: "NootchIcon", withExtension: "png") != nil)
+}
+
+@Test func resourceBundleReturnsNilForMissingResourceInsteadOfTrapping() {
+    #expect(ResourceBundle.url(forResource: "definitely-not-a-resource", withExtension: "svg") == nil)
+}
+
+// Every provider that advertises a logo must actually ship one, otherwise the
+// rail silently falls back to an SF Symbol.
+@Test func everyProviderLogoResourceIsPresent() {
+    for provider in ProviderID.allCases {
+        guard let resource = provider.logoResource else { continue }
+        #expect(
+            ResourceBundle.url(forResource: resource, withExtension: nil) != nil,
+            "missing logo resource \(resource) for \(provider.rawValue)")
+    }
+}

--- a/Tests/NootchTests/TokenCacheTests.swift
+++ b/Tests/NootchTests/TokenCacheTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Testing
+@testable import Nootch
+
+// A settable clock, so the TTL and backoff behaviour can be checked without
+// waiting minutes for real time to pass.
+private final class TestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var now = Date(timeIntervalSince1970: 1_000_000)
+
+    var date: Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return now
+    }
+
+    func advance(_ interval: TimeInterval) {
+        lock.lock()
+        defer { lock.unlock() }
+        now += interval
+    }
+}
+
+private struct Loader {
+    let clock = TestClock()
+    private let box = Box()
+
+    final class Box: @unchecked Sendable {
+        let lock = NSLock()
+        var reads = 0
+        var result: TokenLookup = .found("first")
+    }
+
+    var reads: Int { box.lock.withLock { box.reads } }
+    func setResult(_ result: TokenLookup) { box.lock.withLock { box.result = result } }
+
+    func load() -> TokenLookup {
+        box.lock.withLock {
+            box.reads += 1
+            return box.result
+        }
+    }
+}
+
+@Test func cachedTokenIsReusedWithinTTL() {
+    let loader = Loader()
+    let cache = TokenCache(now: { loader.clock.date })
+
+    #expect(cache.value(loader: loader.load) == "first")
+    loader.clock.advance(TokenCache.foundTTL - 1)
+    #expect(cache.value(loader: loader.load) == "first")
+    // One read, not one per refresh: this is what keeps the password dialog
+    // from appearing every 30 seconds.
+    #expect(loader.reads == 1)
+
+    loader.clock.advance(2)
+    loader.setResult(.found("second"))
+    #expect(cache.value(loader: loader.load) == "second")
+    #expect(loader.reads == 2)
+}
+
+// A missing credential is cheap to re-read and raises no prompt, so it must
+// expire quickly — otherwise `claude login` would not be noticed for minutes.
+@Test func absentTokenExpiresSoonerThanADeniedOne() {
+    #expect(TokenCache.absentTTL < TokenCache.foundTTL)
+    #expect(TokenCache.deniedTTL > TokenCache.foundTTL)
+
+    let loader = Loader()
+    loader.setResult(.absent)
+    let cache = TokenCache(now: { loader.clock.date })
+
+    #expect(cache.value(loader: loader.load) == nil)
+    loader.clock.advance(TokenCache.absentTTL + 1)
+    loader.setResult(.found("after-login"))
+    #expect(cache.value(loader: loader.load) == "after-login")
+}
+
+// A refused Keychain must not be retried straight away; each retry is another
+// password dialog.
+@Test func deniedTokenIsNotRetriedImmediately() {
+    let loader = Loader()
+    loader.setResult(.denied)
+    let cache = TokenCache(now: { loader.clock.date })
+
+    #expect(cache.value(loader: loader.load) == nil)
+    loader.clock.advance(TokenCache.absentTTL + 1)
+    #expect(cache.value(loader: loader.load) == nil)
+    #expect(loader.reads == 1)
+}
+
+// Regression: invalidate() used to re-arm the floor on every rejection. With
+// the 30s refresh loop rejecting continuously, the floor was pushed out before
+// it could ever lapse, so the Keychain was never read again and a re-login went
+// unnoticed until restart.
+@Test func repeatedRejectionsStillAllowAReadOnceTheFloorLapses() {
+    let loader = Loader()
+    let cache = TokenCache(now: { loader.clock.date })
+    #expect(cache.value(loader: loader.load) == "first")
+
+    // Simulate the refresh loop: every 30s the stale token is served and
+    // rejected again, for longer than the floor.
+    loader.setResult(.found("renewed"))
+    var elapsed: TimeInterval = 0
+    while elapsed < TokenCache.reloadFloor {
+        cache.invalidate()
+        loader.clock.advance(30)
+        elapsed += 30
+        _ = cache.value(loader: loader.load)
+    }
+
+    // Once the floor has genuinely lapsed the cache must read again and pick up
+    // the token the user just refreshed.
+    #expect(cache.value(loader: loader.load) == "renewed")
+    #expect(loader.reads == 2)
+}
+
+// The floor exists so that a token the API keeps refusing does not become a
+// password dialog every cycle.
+@Test func rejectionHoldsOffTheNextReadUntilTheFloorLapses() {
+    let loader = Loader()
+    let cache = TokenCache(now: { loader.clock.date })
+    #expect(cache.value(loader: loader.load) == "first")
+
+    cache.invalidate()
+    loader.clock.advance(30)
+    // Still inside the floor: no new read, and the stale token keeps being
+    // served so the "login expired" error stays in place.
+    #expect(cache.value(loader: loader.load) == "first")
+    #expect(loader.reads == 1)
+}

--- a/Tests/NootchTests/TokenCacheTests.swift
+++ b/Tests/NootchTests/TokenCacheTests.swift
@@ -128,3 +128,23 @@ private struct Loader {
     #expect(cache.value(loader: loader.load) == "first")
     #expect(loader.reads == 1)
 }
+
+// A Keychain read can sit behind a password dialog for longer than the TTL.
+// Dating the entry from before the read would make it expired the moment it
+// arrives, so the next cycle reads again and prompts again — the storm this
+// cache exists to stop.
+@Test func slowLoadStillYieldsAUsableEntry() {
+    let loader = Loader()
+    let cache = TokenCache(now: { loader.clock.date })
+
+    let token = cache.value(loader: {
+        // The user left the password dialog on screen well past foundTTL.
+        loader.clock.advance(TokenCache.foundTTL * 2)
+        return loader.load()
+    })
+    #expect(token == "first")
+
+    // The entry is dated from when the read returned, so it is still live.
+    #expect(cache.value(loader: loader.load) == "first")
+    #expect(loader.reads == 1)
+}

--- a/packaging/build-app.sh
+++ b/packaging/build-app.sh
@@ -17,12 +17,34 @@ mkdir -p "$STAGE" "$DIST/$APP_NAME.app/Contents/MacOS" "$DIST/$APP_NAME.app/Cont
 cp "$ROOT/.build/release/$APP_NAME" "$DIST/$APP_NAME.app/Contents/MacOS/"
 cp "$ROOT/packaging/Info.plist" "$DIST/$APP_NAME.app/Contents/"
 cp "$ROOT/Sources/Nootch/Resources/Nootch.icns" "$DIST/$APP_NAME.app/Contents/Resources/"
-if [ -d "$ROOT/.build/release/${APP_NAME}_Nootch.bundle" ]; then
-    cp -R "$ROOT/.build/release/${APP_NAME}_Nootch.bundle" "$DIST/$APP_NAME.app/Contents/Resources/"
+# The resource bundle is not optional: without it every logo and the app icon
+# silently disappear. Fail here rather than shipping a DMG that is missing them.
+BUNDLE="$ROOT/.build/release/${APP_NAME}_Nootch.bundle"
+if [ ! -d "$BUNDLE" ]; then
+    echo "error: $BUNDLE not found; cannot package without resources" >&2
+    exit 1
 fi
+# Keep resources under Contents/Resources. Placing the bundle at the app root to
+# satisfy SwiftPM's Bundle.module would leave unsealed contents there, which
+# invalidates the signature and stops Keychain "Always Allow" from ever
+# sticking. ResourceBundle.swift looks here instead.
+cp -R "$BUNDLE" "$DIST/$APP_NAME.app/Contents/Resources/"
 
-# Ad-hoc sign so Gatekeeper treats the bundle like the previous release.
-codesign --force --deep --sign - "$DIST/$APP_NAME.app"
+# Sign with a real Developer ID when one is available, so the app has a stable
+# code signing identity across releases. Keychain ACL entries are keyed on that
+# identity; an ad-hoc signature falls back to the binary's cdhash, which changes
+# on every build and silently voids any previous "Always Allow" grant.
+CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+if [ "$CODESIGN_IDENTITY" = "-" ]; then
+    # Ad-hoc, as before. The hardened runtime is skipped here because it only
+    # buys anything alongside notarization, which needs a real identity.
+    codesign --force --deep --sign - "$DIST/$APP_NAME.app"
+else
+    codesign --force --deep --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$DIST/$APP_NAME.app"
+fi
+# A bundle that fails verification has no usable code requirement, so Keychain
+# prompts return on every read. Catch that here instead of in the wild.
+codesign --verify --strict --verbose=2 "$DIST/$APP_NAME.app"
 
 rm -rf "$STAGE"
 mkdir -p "$STAGE"

--- a/packaging/build-app.sh
+++ b/packaging/build-app.sh
@@ -35,12 +35,15 @@ cp -R "$BUNDLE" "$DIST/$APP_NAME.app/Contents/Resources/"
 # identity; an ad-hoc signature falls back to the binary's cdhash, which changes
 # on every build and silently voids any previous "Always Allow" grant.
 CODESIGN_IDENTITY="${CODESIGN_IDENTITY:--}"
+# --deep is deprecated by Apple and unnecessary here: the only nested bundle is
+# nootch_Nootch.bundle, which holds resources and no executable code, so it is
+# covered by the app's own resource seal.
 if [ "$CODESIGN_IDENTITY" = "-" ]; then
     # Ad-hoc, as before. The hardened runtime is skipped here because it only
     # buys anything alongside notarization, which needs a real identity.
-    codesign --force --deep --sign - "$DIST/$APP_NAME.app"
+    codesign --force --sign - "$DIST/$APP_NAME.app"
 else
-    codesign --force --deep --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$DIST/$APP_NAME.app"
+    codesign --force --options runtime --timestamp --sign "$CODESIGN_IDENTITY" "$DIST/$APP_NAME.app"
 fi
 # A bundle that fails verification has no usable code requirement, so Keychain
 # prompts return on every read. Catch that here instead of in the wild.


### PR DESCRIPTION
Fixes #1.

Two problems, one shared root cause in how the `.app` is assembled.

## 1. `Bundle.module` kills the app on every machine but the build machine

`Bundle.module` resolves the resource bundle relative to the executable, which for an `.app` is the **bundle root**. `build-app.sh` copies it into `Contents/Resources/`, so the lookup misses, and SwiftPM's generated accessor responds to a miss with `assertionFailure` — the app dies inside `applicationDidFinishLaunching` before it ever draws. `LSUIElement` is `true`, so there is no window and no Dock icon, and the failure is completely silent.

The only reason this shipped is that the accessor's second candidate path is the absolute path of *your* build directory, which still exists on your machine. On any other machine both candidates miss.

### Reproduced

Building 1.0.4 unpatched and running it on this machine works, because `.build/arm64-apple-macosx/release/nootch_Nootch.bundle` is present. Renaming that one directory to simulate a clean machine:

```
$ ./dist/nootch.app/Contents/MacOS/nootch
Nootch/resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle:
from .../dist/nootch.app/nootch_Nootch.bundle
or  .../.build/arm64-apple-macosx/release/nootch_Nootch.bundle
```

### Fix

New `ResourceBundle.swift` searches `Contents/Resources`, then the executable's directory, then the main bundle, and returns `Bundle.main` rather than trapping. Both call sites (`ProviderLogo`, the app icon in `NootchApp`) already use `if let` and degrade to an SF Symbol, so a miss now costs a logo instead of the process.

I deliberately did **not** fix this by moving the bundle to the app root, which is the obvious one-line change — see below for why that would have made problem 2 permanent.

## 2. Keychain prompts that never stop

`Always Allow` does nothing. The password dialog for `Claude Code-credentials` comes back every time, several times a session.

The reason is that the shipped app fails signature verification:

```
$ codesign --verify --strict --verbose=2 /Applications/nootch.app
/Applications/nootch.app: unsealed contents present in the bundle root
$ spctl -a -vv /Applications/nootch.app
/Applications/nootch.app: rejected
```

A Keychain ACL stores a **code requirement** for the app it trusts. An unverifiable bundle has no usable requirement, so the grant cannot be persisted at all. On top of that, an ad-hoc `codesign --sign -` has no stable identity even when it does verify — the requirement degrades to the binary's `cdhash`, which changes on every build, so a grant that did stick is silently voided by the next release.

This is also why moving the resource bundle to the app root is the wrong fix for problem 1: it leaves unsealed contents in the root and makes the app permanently unverifiable, trading a crash for a Keychain prompt that can never be dismissed for good.

On top of that, the token was read straight from the Keychain on every 30s refresh, so each cycle was a potential dialog.

### Fix

- **Keep the bundle sealed.** Resources stay in `Contents/Resources`; `ResourceBundle.swift` is what makes that possible.
- **`CODESIGN_IDENTITY` env var.** Defaults to `-`, so nothing changes for you by default. Set it to a Developer ID and the script signs with the hardened runtime and a timestamp instead. This is the actual fix for the cross-version case.
- **`codesign --verify --strict` gate** after signing, so a build that cannot be verified fails in the script rather than in the wild.
- **Cache the token**, keyed on what the lookup actually returned rather than one flat TTL:
  - a hit lasts 5 minutes;
  - `errSecItemNotFound` ("nothing stored") lasts only 30 seconds, because re-reading raises no dialog and a fresh `claude login` should show up promptly;
  - any other failure (cancelled prompt, auth failed) lasts 10 minutes, because re-reading *is* another dialog.
- **Back off after a rejected token.** A 401/403 expires the entry but holds a two-minute floor before the next Keychain read, so a token the API keeps refusing cannot become a dialog every cycle. The stale value is served in the meantime so the "login expired" message stays put instead of the row flipping to undetected. The invalidation is skipped when the token came from `CLAUDE_CODE_OAUTH_TOKEN`, which never enters the cache.
- **`~/.claude/.credentials.json` fallback**, tried only after the Keychain, so the Keychain stays authoritative and a stale file can never shadow a fresh token.
- **Log when the resource fallback is taken**, since a silent fallback costs the dock icon and every provider logo and is otherwise invisible under `LSUIElement`.
- **Hard-fail if the resource bundle is missing** instead of the previous `if [ -d ... ]`, which would quietly package a DMG with no logos.

## Verified

- `swift build -c release` passes, and all 21 tests pass (`swift test`, Xcode toolchain — the CommandLineTools SDK has no `Testing` module).
- Three regression tests added, including one asserting every provider that advertises a logo actually ships the asset.
- Packaged the app with the patched script, hid `.build` to simulate a clean machine, and confirmed it launches, shows the notch panel and renders provider logos.
- `codesign --verify --strict` passes on the packaged app: `valid on disk`, `satisfies its Designated Requirement`. The pre-fix bundle failed this.

## On signing

The `CODESIGN_IDENTITY` hook is there but ad-hoc is still the default, so releases behave as before unless you opt in.

If it is useful, I am happy to sign and notarize a release under my own Apple Developer account. Worth being clear about the trade-off rather than just offering: Apple's Developer Program License Agreement makes the signer the responsible party for the software they ship, so those builds would carry my Team ID and my name, and users would see my identity rather than yours in Gatekeeper. Notarizing an open-source app you built yourself is permitted, but it is genuinely better for you to sign your own releases if you can — the identity should be the project's. Treat my offer as a stopgap if you do not have a paid account right now, not as the preferred outcome.

Either way, the ad-hoc default in this PR still fixes the crash, and the `--verify` gate still prevents shipping an unverifiable bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pvjyz81EiXV9d7EeobF1uK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed packaged app resource loading to prevent launch issues and ensure provider logos display correctly.
  - Improved Claude credential refresh after authorization failures, including more reliable retry timing and credential rereading.
  - Improved token caching when credential reads are delayed or credentials are unavailable.

- **Packaging**
  - Strengthened checks to ensure required resources are included.
  - Improved code-signing support and verification.

- **Tests**
  - Added coverage for resource resolution, provider logos, missing resources, and credential caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the silent 1.0.4 launch crash and the endless Keychain prompts. The app now locates its resource bundle and caches Keychain reads so the refresh loop can't prompt every cycle.

**Bug Fixes**
- Replaces `Bundle.module` with `ResourceBundle`, which searches `Contents/Resources` and the executable directory and returns `Bundle.main` instead of crashing when nothing is found.
- Keeps the resource bundle under `Contents/Resources` so the bundle root stays sealed and the signature stays verifiable; an unverifiable app can't persist Keychain "Always Allow".
- Caches the Keychain token with TTLs keyed on lookup result: 5 minutes for a hit, 30 seconds when nothing is stored, 10 minutes when the Keychain refuses. Entries are dated from when the read returns, so a slow password prompt can't leave one already expired.
- Backs off two minutes after a 401/403 so a rejected token can't raise a prompt every 30-second cycle; the floor arms once so a re-login is eventually noticed.
- Tries `~/.claude/.credentials.json` only after the Keychain, so a stale file can't shadow a fresh token.
- Splits resource lookup into `searchPaths` and `locate` and adds regression tests covering the miss path, the floor rearming, slow Keychain reads, and every shipped logo.

**Migration**
- Set `CODESIGN_IDENTITY` to a Developer ID to sign with the hardened runtime and timestamp; the default remains ad-hoc.
- The build script now fails when the resource bundle is missing or the signature doesn't verify.

<sup>Written for commit 96369608ddd3ef1130f4a1cef53f56d9d36a27b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DeepanshuMishraa/nootch/pull/2?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

